### PR TITLE
Minor improvement to Dockerfile and add missing bash shebang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM node:10.9.0
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY ./package.json /usr/src/app/
-RUN yarn install
+
 COPY . /usr/src/app
+
+RUN yarn install
+
 ENTRYPOINT sh startup.sh

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,3 @@
-yarn build
-yarn serve
+#!/bin/bash
+
+yarn build && yarn serve

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
-yarn tslint
-yarn test
-yarn build
+#!/bin/bash
+
+yarn tslint && yarn test && yarn build


### PR DESCRIPTION
This PR:

* Removes duplicated COPY directive in Dockerfile.
* Organizes the Dockerfile to make it more readable, and pushes the `RUN yarn install` command at the bottom for better cache capabilities`.
* Adds missing bash shebang to some `.sh` files.
* Short-circuit the `.sh` sentences by joining them using Bash AND (`&&`).